### PR TITLE
Added Custom Model Serving with Llama3 to use as the LLM for RAG 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,85 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+utils/config.py
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json

--- a/02-OpenAI-External-Models/External-Models-OpenAI-Langchain-MLflow-Text-QA.py
+++ b/02-OpenAI-External-Models/External-Models-OpenAI-Langchain-MLflow-Text-QA.py
@@ -238,9 +238,12 @@ client.create_endpoint(
 # COMMAND ----------
 
 # DBTITLE 1,Save initial data to a table in Unity Catalog
+from pyspark.sql.types import StructType, StructField, StringType, LongType
 from pyspark.sql.functions import col, monotonically_increasing_id
 from langchain.text_splitter import CharacterTextSplitter
 from langchain_community.document_loaders import WebBaseLoader
+
+schema = StructType([StructField('page_content', StringType(), True), StructField('type', StringType(), True), StructField('id', LongType(), True)])
 
 loader = WebBaseLoader("https://mlflow.org/docs/latest/index.html")
 documents = loader.load()
@@ -250,8 +253,7 @@ documents = loader.load()
 text_splitter = CharacterTextSplitter(chunk_size=512, chunk_overlap=32)
 docs = text_splitter.split_documents(documents)
 
-
-df = spark.createDataFrame(docs).drop(col("metadata")).withColumn("id", monotonically_increasing_id())
+df = spark.createDataFrame(docs, schema).drop(col("metadata")).withColumn("id", monotonically_increasing_id())
 
 display(df)
 

--- a/03-Served-Llama3-Custom-Models/01-Pull-and-Deploy-Llama3.py
+++ b/03-Served-Llama3-Custom-Models/01-Pull-and-Deploy-Llama3.py
@@ -1,0 +1,244 @@
+# Databricks notebook source
+# MAGIC %md
+# MAGIC # Evaluation of RAG (Retrieval-Augmented Generation) chain using Databricks Model Serving (Llama3-8b) and MLflow!
+# MAGIC
+# MAGIC - We will use langchain to pull MLflow documentation and chunk it. 
+# MAGIC - We will pull meta-llama/Meta-Llama-3-8B-Instruct and deploy to Databricks Model Serving. 
+# MAGIC - We will use the Databricks Model Serving endpoint to automatically compute embeddings from the chunks. 
+# MAGIC - We will then create an index within a Databricks Vector Search index to hold the embeddings and act as a retriever for our RAG chain. 
+# MAGIC - We log all of this in mlflow so that we can have the run history and associated artifacts stored!
+# MAGIC - After creating the RAG chain, we will set up our evaluation metrics including toxicity and faithfulness. 
+# MAGIC   - We will be using an additional LLM from the Foundation Model APIs to perform LLM-as-a-judge on our outputs. 
+# MAGIC - Finally, we will evaluate our RAG chain and display the results! 
+
+# COMMAND ----------
+
+# DBTITLE 1,Install / Update dependencies
+# MAGIC %pip install -U langchain langchain_community databricks-vectorsearch mlflow
+# MAGIC
+# MAGIC # Version locked if needed [outside of ML Databricks Runtime]: 
+# MAGIC # langchain==0.0.348 langchain_community==0.0.1 databricks-vectorsearch==0.36
+# MAGIC
+# MAGIC dbutils.library.restartPython()
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ### Update your Unity Catalog values below:
+
+# COMMAND ----------
+
+# MAGIC %run ".././utils/setup" $catalog_name="will_smith" $schema_name="llama_3_custom_eval" $volume_name="llama_3_custom_eval_vol" $vector_search_endpoint_name="one-env-shared-endpoint-7"
+
+# COMMAND ----------
+
+# %run ".././utils/setup" $catalog_name="CATALOG" $schema_name="llama_3_custom_eval" $volume_name="llama_3_custom_eval_vol" $vector_search_endpoint_name="VECTOR_SEARCH"
+
+# COMMAND ----------
+
+# MAGIC %run ".././utils/helpers" 
+
+# COMMAND ----------
+
+# DBTITLE 1,Creating Catalog
+if(spark.sql(f"CREATE CATALOG IF NOT EXISTS {catalog_name}")):
+  print(f"Catalog [{catalog_name}] created successfully!")
+
+# COMMAND ----------
+
+# DBTITLE 1,Creating Schema
+if(spark.sql(f"CREATE SCHEMA IF NOT EXISTS {catalog_name}.{schema_name}")):
+  print(f"Schema [{catalog_name}.{schema_name}] created successfully!")
+
+# COMMAND ----------
+
+# DBTITLE 1,Create Vector Search Schema
+if(spark.sql(f"CREATE SCHEMA IF NOT EXISTS {catalog_name}.{vector_index_schema}")):
+  print(f"SCHEMA [{catalog_name}.{vector_index_schema}] created successfully!")
+
+# COMMAND ----------
+
+# DBTITLE 1,Creating a Databricks Volume
+if(spark.sql(f"CREATE VOLUME IF NOT EXISTS {catalog_name}.{schema_name}.{volume_name}")):
+  print(f"Volume [{catalog_name}.{schema_name}.{volume_name}] created successfully!")
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Pull the model from Huggingface with appropriate values:
+
+# COMMAND ----------
+
+model_name = "meta-llama/Meta-Llama-3-8B-Instruct"
+revision = "e1945c40cd546c78e41f1151f4db032b271faeaa"
+secret_scope = "william_smith_secrets"
+secret_key = "HF_KEY"
+model_save_path = f"{uc_save_path}.llama3_8b_evaluation"
+
+# COMMAND ----------
+
+from huggingface_hub import login
+
+login(token=dbutils.secrets.get('william_smith_secrets', 'HF_KEY'))
+
+# COMMAND ----------
+
+# Load 16 bit model fails due to OOM
+from transformers import AutoTokenizer, AutoModelForCausalLM
+import torch
+
+model_id = "meta-llama/Meta-Llama-3-8B-Instruct"
+
+tokenizer = AutoTokenizer.from_pretrained(model_id)
+model = AutoModelForCausalLM.from_pretrained(
+    model_id,
+    torch_dtype=torch.bfloat16,
+    device_map="cuda",
+)
+
+# COMMAND ----------
+
+messages = [
+    {"role": "system", "content": "You are an expert on MLOps and Large Language Models."},
+    {"role": "user", "content": "What is the MLOps processing described in steps?"}
+]
+
+input_ids = tokenizer.apply_chat_template(
+    messages,
+    add_generation_prompt=True,
+    return_tensors="pt"
+).to(model.device)
+
+terminators = [
+    tokenizer.eos_token_id,
+    tokenizer.convert_tokens_to_ids("<|eot_id|>")
+]
+
+outputs = model.generate(
+    input_ids,
+    max_new_tokens=256,
+    eos_token_id=terminators,
+    do_sample=True,
+    temperature=0.6,
+    top_p=0.9,
+)
+response = outputs[0][input_ids.shape[-1]:]
+final_output = tokenizer.decode(response, skip_special_tokens=True)
+
+# COMMAND ----------
+
+import mlflow 
+from mlflow.models.signature import infer_signature
+
+inference_config = {"max_new_tokens": 500, "temperature": 0.8}
+signature = infer_signature(messages, final_output, params=inference_config)
+
+mlflow.set_registry_uri('databricks-uc')
+
+with mlflow.start_run() as run:
+    components = {
+        "model": model,
+        "tokenizer": tokenizer,
+    }
+    model_info = mlflow.transformers.log_model(
+        transformers_model=components,
+        artifact_path= model_save_path,
+        inference_config=inference_config,
+        registered_model_name= model_save_path,
+        input_example=messages,
+        signature=signature,
+        pip_requirements=["torch", "transformers==4.41.1", "accelerate", "huggingface_hub==0.23.2", "sentencepiece", "mlflow==2.13.0"],
+    )
+    run_id = run.info.run_id
+
+# COMMAND ----------
+
+import mlflow
+
+# Get the run ID from the last MLflow call
+# last_run_id = run_id
+
+# Construct the logged model URI
+# logged_model_uri = f"runs:/{last_run_id}/{model_save_path}"
+
+logged_model_uri = 'runs:/788046d477a6459f91638a37ab8e3d3a/will_smith.llama_3_custom_eval.llama3_8b_evaluation'
+
+# Load model as a PyFuncModel
+loaded_model = mlflow.transformers.load_model(logged_model_uri, device=0)
+
+# COMMAND ----------
+
+messages = [
+    {"role": "system", "content": "You are an expert on MLOps and Large Language Models."},
+    {"role": "user", "content": "What is the MLOps processing described in steps?"}
+]
+
+input_ids = tokenizer.apply_chat_template(
+    messages,
+    add_generation_prompt=True,
+    return_tensors="pt"
+).to(model.device)
+
+terminators = [
+    tokenizer.eos_token_id,
+    tokenizer.convert_tokens_to_ids("<|eot_id|>")
+]
+
+outputs = model.generate(
+    input_ids,
+    max_new_tokens=256,
+    eos_token_id=terminators,
+    do_sample=True,
+    temperature=0.6,
+    top_p=0.9,
+)
+response = outputs[0][input_ids.shape[-1]:]
+final_output = tokenizer.decode(response, skip_special_tokens=True)
+
+print(final_output)
+
+# COMMAND ----------
+
+# You should specify the newest model version to load for inference
+version = "1"
+model_name = "llama_3_8b_evaluation"
+model_uc_path = model_save_path
+endpoint_name = f'{model_name}_ws'
+
+# Choose the right workload types based on the model size 
+# NOTE: FOR SOME REASON THIS IS NOT WORKING SO HARDCODED THE CONFIG
+workload_type = "GPU_LARGE"
+workload_size = "Small"
+
+# COMMAND ----------
+
+from mlflow.deployments import get_deploy_client
+
+client = get_deploy_client("databricks")
+endpoint = client.create_endpoint(
+    name= endpoint_name,
+    config={
+        "served_entities": [
+            {
+                "name": endpoint_name,
+                "entity_name": model_uc_path,
+                "entity_version": "1",
+                "workload_type": "GPU_LARGE",
+                "workload_size": workload_size,
+                "scale_to_zero_enabled": True
+            }
+        ],
+        "traffic_config": {
+            "routes": [
+                {
+                    "served_model_name": endpoint_name,
+                    "traffic_percentage": 100
+                }
+            ]
+        }
+    }
+)
+
+# COMMAND ----------
+
+

--- a/03-Served-Llama3-Custom-Models/02-Llama3-Custom-Langchain-MLflow-Text-QA.py
+++ b/03-Served-Llama3-Custom-Models/02-Llama3-Custom-Langchain-MLflow-Text-QA.py
@@ -28,7 +28,11 @@
 
 # COMMAND ----------
 
-# MAGIC %run ".././utils/setup" $catalog_name="CATALOG" $schema_name="llama_3_custom_eval" $volume_name="llama_3_custom_eval_vol" $vector_search_endpoint_name="VECTOR_SEARCH"
+# MAGIC %run ".././utils/setup" $catalog_name="will_smith" $schema_name="llama_3_custom_eval" $volume_name="llama_3_custom_eval_vol" $vector_search_endpoint_name="one-env-shared-endpoint-7"
+
+# COMMAND ----------
+
+# %run ".././utils/setup" $catalog_name="CATALOG" $schema_name="llama_3_custom_eval" $volume_name="llama_3_custom_eval_vol" $vector_search_endpoint_name="VECTOR_SEARCH"
 
 # COMMAND ----------
 
@@ -60,21 +64,31 @@ if(spark.sql(f"CREATE VOLUME IF NOT EXISTS {catalog_name}.{schema_name}.{volume_
 
 # COMMAND ----------
 
+uc_save_path
+
+# COMMAND ----------
+
+from pyspark.sql.types import StructType, StructField, StringType, LongType
 from pyspark.sql.functions import col, monotonically_increasing_id
 from langchain.text_splitter import CharacterTextSplitter
 from langchain_community.document_loaders import WebBaseLoader
+
+schema = StructType([StructField('page_content', StringType(), True), StructField('type', StringType(), True), StructField('id', LongType(), True)])
 
 loader = WebBaseLoader("https://mlflow.org/docs/latest/index.html")
 documents = loader.load()
 text_splitter = CharacterTextSplitter(chunk_size=512, chunk_overlap=32)
 docs = text_splitter.split_documents(documents)
 
-
-df = spark.createDataFrame(docs).drop(col("metadata")).withColumn("id", monotonically_increasing_id())
+df = spark.createDataFrame(docs, schema).drop(col("metadata")).withColumn("id", monotonically_increasing_id())
 
 display(df)
 
-df.write.option("mergeSchema", "true").mode("overwrite").format("delta").saveAsTable(f"{uc_save_path}.raw_mlflow_docs")
+try:
+  df.write.option("mergeSchema", "true").mode("overwrite").format("delta").saveAsTable(f"{uc_save_path}.raw_mlflow_docs")
+  print(f"Successfully saved table: {uc_save_path}.raw_mlflow_docs!")
+except:
+  print(f"Failed to write table: {uc_save_path}.raw_mlflow_docs.")
 
 # COMMAND ----------
 

--- a/03-Served-Llama3-Custom-Models/Llama3-Custom-Langchain-MLflow-Text-QA.py
+++ b/03-Served-Llama3-Custom-Models/Llama3-Custom-Langchain-MLflow-Text-QA.py
@@ -1,11 +1,11 @@
 # Databricks notebook source
 # MAGIC %md
-# MAGIC # Evaluation of RAG (Retrieval-Augmented Generation) chain using Databricks Foundation Model APIs and MLflow!
+# MAGIC # Evaluation of RAG (Retrieval-Augmented Generation) chain using Databricks Model Serving (Llama3-8b) and MLflow!
 # MAGIC
 # MAGIC - We will use langchain to pull MLflow documentation and chunk it. 
-# MAGIC - We will use the Databricks Foundation Model APIs to automatically compute embeddings from the chunks. 
+# MAGIC - We will pull meta-llama/Meta-Llama-3-8B-Instruct and deploy to Databricks Model Serving. 
+# MAGIC - We will use the Databricks Model Serving endpoint to automatically compute embeddings from the chunks. 
 # MAGIC - We will then create an index within a Databricks Vector Search index to hold the embeddings and act as a retriever for our RAG chain. 
-# MAGIC - DBRX from the Databricks Foundation Model APIs will be our primary model for our RAG chain.
 # MAGIC - We log all of this in mlflow so that we can have the run history and associated artifacts stored!
 # MAGIC - After creating the RAG chain, we will set up our evaluation metrics including toxicity and faithfulness. 
 # MAGIC   - We will be using an additional LLM from the Foundation Model APIs to perform LLM-as-a-judge on our outputs. 
@@ -28,7 +28,7 @@
 
 # COMMAND ----------
 
-# MAGIC %run ".././utils/setup" $catalog_name="CATALOG" $schema_name="fmapi_eval" $volume_name="fmapi_vol" $vector_search_endpoint_name="VECTOR_SEARCH"
+# MAGIC %run ".././utils/setup" $catalog_name="CATALOG" $schema_name="llama_3_custom_eval" $volume_name="llama_3_custom_eval_vol" $vector_search_endpoint_name="VECTOR_SEARCH"
 
 # COMMAND ----------
 

--- a/utils/setup.py
+++ b/utils/setup.py
@@ -32,7 +32,3 @@ llm_model = dbutils.widgets.get("llm_model")
 embeddings_model = dbutils.widgets.get("embeddings_model")
 vector_index_name = dbutils.widgets.get("vector_index")
 vector_index_schema = dbutils.widgets.get("vse_schema_name")
-
-# COMMAND ----------
-
-


### PR DESCRIPTION
Created two notebooks:

1. Pulls the model weights from Huggingface, logs to mlflow, and deploys to a Databricks model serving endpoint
2. Uses the created endpoint in a langchain RAG chain using Databricks Vector Search. 

The chain is then evaluated using mlflow.evaluate()